### PR TITLE
Fix encoding errors

### DIFF
--- a/src/main/java/mixer/mcc/command/DisplayCreditsCommand.java
+++ b/src/main/java/mixer/mcc/command/DisplayCreditsCommand.java
@@ -14,7 +14,7 @@ public class DisplayCreditsCommand implements Command, Runnable {
     @Override
     public void execute() {
         // XXX Breaks the gui if alwaysOnTop in the MainFrame is active!!!
-         JOptionPane.showMessageDialog(null, "MCC © 2019 d33pfr13d", "Credits",
+         JOptionPane.showMessageDialog(null, "MCC (c) 2019 d33pfr13d", "Credits",
          JOptionPane.INFORMATION_MESSAGE);
     }
 

--- a/src/main/java/mixer/mcc/gui/MainPanel.java
+++ b/src/main/java/mixer/mcc/gui/MainPanel.java
@@ -42,8 +42,8 @@ public class MainPanel extends JPanel {
 		
 		jbLive.setMnemonic(KeyEvent.VK_L);
 		
-		//TODO Wahrscheinlich würde man das konfiguerbar haben wollen, wobei man
-		//überhaupt alle actions konfigurierbar haben will und nicht feste buttons!!!
+		//TODO Wahrscheinlich wÃ¼rde man das konfiguerbar haben wollen, wobei man
+		//Ãœberhaupt alle actions konfigurierbar haben will und nicht feste buttons!!!
 		// -> generisches "Play Video Command" das man dann per properties x-mal spawnen kann
 		// Man braucht auch keinen settings dialog, ne props file finde ich viel komfortabler ^^
 		final JTextArea jtVideo = new JTextArea("D:\\data\\Programme\\Telegram\\media\\on-a-boat-clipped.mp4");

--- a/src/main/java/mixer/mcc/services/vlc/VlcConnector.java
+++ b/src/main/java/mixer/mcc/services/vlc/VlcConnector.java
@@ -21,9 +21,9 @@ import jonas.tools.execution.CommandLineUtils;
 public class VlcConnector {
 	
 	/**
-	 * TODO Das soll aus ner properties Datei kommen, wir brauchen dafür ein Konfigurations-Modul.
+	 * TODO Das soll aus ner properties Datei kommen, wir brauchen dafÃ¼r ein Konfigurations-Modul.
 	 * 
-	 * TODO FIXEM KOMMT NICHT MIT SPACES KLAR -> MÜSSTE RUNTIME.EXEC in JUT mit array aufrufen!!!
+	 * TODO FIXEM KOMMT NICHT MIT SPACES KLAR -> MÃœSSTE RUNTIME.EXEC in JUT mit array aufrufen!!!
 	 * -> workaorund mit mklink /J VLC <ACTUAL-PATH> nen kurzen pfad erstellen in cmd!!!
 	 */
 	private static String VLC_PATH = "D:\\Programme\\VLC\\";


### PR DESCRIPTION
`mvn package` as well as IntelliJ on macOS would report these umlauts as encoding errors so that the compilation fails. I've recreated the umlauts in UTF-8.